### PR TITLE
feat(FIRASim): adding base project and submodules to FIRASim environment

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,26 +7,26 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+# Describe the bug
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+# To Reproduce
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+# Expected behavior
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+# Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
+# Desktop (please complete the following information):
  - OS: [e.g. Ubuntu]
  - Version [e.g. 22.04]
 
-**Additional context**
+# Additional context
 Add any other context about the problem here.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a bug report from the project
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. Ubuntu]
+ - Version [e.g. 22.04]
+
+**Additional context**
+Add any other context about the problem here.
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'feature'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe the task workflow for this feature**
+| Task | Time required |  Assigned to | Current Status | Finished | 
+|------|-----------------|---------------|-----------------|----------|
+| Refactor to use smartpointers (#id) | 3 days | @user @user2 | Done | :white_check_mark:
+| Creating the best attacker (#id) | 1 week | @user | In progress | :white_large_square:
+| Integration tests | 24 hours | @user | Waiting (#id) | :white_large_square:
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,21 +7,21 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+# Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+# Describe the solution you'd like
 A clear and concise description of what you want to happen.
 
-**Describe the task workflow for this feature**
+# Describe the task workflow for this feature
 | Task | Time required |  Assigned to | Current Status | Finished | 
 |------|-----------------|---------------|-----------------|----------|
 | Refactor to use smartpointers (#id) | 3 days | @user @user2 | Done | :white_check_mark:
 | Creating the best attacker (#id) | 1 week | @user | In progress | :white_large_square:
 | Integration tests | 24 hours | @user | Waiting (#id) | :white_large_square:
 
-**Describe alternatives you've considered**
+# Describe alternatives you've considered
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+# Additional context
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,21 @@
+---
+name: Task
+about: Create a task for this project
+title: ''
+labels: 'task'
+assignees: ''
+
+---
+
+**Is your task related to a feature or bug? Please describe.**
+A clear and concise description of what this task is related to. Ex. This task aims to solve (#PR_ID) [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you will work to. Please use checkboxes here.
+
+- [x] SubTask 1
+- [ ] SubTask 2 (#id)
+- [ ] SubTask 3
+
+**Additional context**
+Add any other context or screenshots about the task here.

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -7,15 +7,15 @@ assignees: ''
 
 ---
 
-**Is your task related to a feature or bug? Please describe.**
+# Is your task related to a feature or bug? Please describe.
 A clear and concise description of what this task is related to. Ex. This task aims to solve (#PR_ID) [...]
 
-**Describe the solution you'd like**
+# Describe the solution you'd like
 A clear and concise description of what you will work to. Please use checkboxes here.
 
 - [x] SubTask 1
 - [ ] SubTask 2 (#id)
 - [ ] SubTask 3
 
-**Additional context**
+# Additional context
 Add any other context or screenshots about the task here.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,28 @@
+---
+name: Pull request
+about: Create a pull request to the project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+# What is the proposal of this pull request?
+A clear and concise description of the main proposal of this pull request.
+
+# What changes have been made?
+Describe which types of changes (features, hotfixes, rewriten, etc) were made on macro classes.
+
+# How to test this changes?
+Describe the steps to test or a dictated explanation to test the changes (the main archives to edit and what to edit).
+
+# References (screenshots, links, etc)
+
+# Checklist
+- [ ] I have performed a self review on my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have checked my code and corrected any misspellings
+- [ ] My changes generated no new warnings
+
+# Additional context
+Add any other context or screenshots about this pull request here.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build
+on:
+  push:
+    paths-ignore:
+      - 'docs**'
+  pull_request:
+jobs:
+  build-ubuntu:
+    runs-on: ${{ matrix.os }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04, ubuntu-22.04 ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: "Install dependencies"
+        run: sudo apt-get update && sudo apt-get install build-essential cmake qtbase5-dev qt5-qmake libprotobuf-dev protobuf-compiler libprotoc-dev protobuf-compiler-grpc libgrpc++-dev libgrpc-dev libqt5serialport5-dev google-mock libgmock-dev libgtest-dev libspdlog-dev libfmt-dev && sudo apt-get upgrade
+      - name: "Install Google Test library"
+        run: cd /usr/src/googletest/googletest/ && sudo cmake CMakeLists.txt && sudo make && cd lib && sudo cp *.a /usr/lib
+      - name: "Install Google Mock library"
+        run: cd /usr/src/googletest/googlemock/ && sudo cmake CMakeLists.txt && sudo make && cd lib && sudo cp *.a /usr/lib
+      - name: "Update ldconfig"
+        run: sudo ldconfig
+      - name: "Build Armorial-PSEL"
+        run: mkdir build && cd build && qmake .. && make -j$(nproc)

--- a/.gitignore
+++ b/.gitignore
@@ -1,52 +1,77 @@
-# C++ objects and libs
-*.slo
-*.lo
-*.o
+# This file is used to ignore files which are generated
+# ----------------------------------------------------------------------------
+
+*~
+*.autosave
 *.a
-*.la
-*.lai
+*.core
+*.moc
+*.o
+*.obj
+*.orig
+*.rej
 *.so
 *.so.*
-*.dll
-*.dylib
-
-# Qt-es
-object_script.*.Release
-object_script.*.Debug
-*_plugin_import.cpp
+*_pch.h.cpp
+*_resource.rc
+*.qm
+.#*
+*.*#
+core
+!core/
+tags
+.DS_Store
+.directory
+*.debug
+Makefile*
+*.prl
+*.app
+moc_*.cpp
+ui_*.h
+qrc_*.cpp
+Thumbs.db
+*.res
+*.rc
 /.qmake.cache
 /.qmake.stash
-*.pro.user
-*.pro.user.*
-*.qbs.user
-*.qbs.user.*
-*.moc
-moc_*.cpp
-moc_*.h
-qrc_*.cpp
-ui_*.h
-*.qmlc
-*.jsc
-Makefile*
-*build-*
-*.qm
-*.prl
 
-# Qt unit tests
-target_wrapper.*
+# qtcreator generated files
+*.pro.user*
 
-# QtCreator
-*.autosave
+# xemacs temporary files
+*.flc
 
-# QtCreator Qml
-*.qmlproject.user
-*.qmlproject.user.*
+# Vim temporary files
+.*.swp
 
-# QtCreator CMake
-CMakeLists.txt.user*
+# Visual Studio generated files
+*.ib_pdb_index
+*.idb
+*.ilk
+*.pdb
+*.sln
+*.suo
+*.vcproj
+*vcproj.*.*.user
+*.ncb
+*.sdf
+*.opensdf
+*.vcxproj
+*vcxproj.*
 
-# QtCreator 4.8< compilation database 
-compile_commands.json
+# MinGW generated files
+*.Debug
+*.Release
 
-# QtCreator local machine specific files for imported projects
-*creator.user*
+# Python byte code
+*.pyc
+
+# Binaries
+# --------
+*.dll
+*.exe
+
+bin/
+build/
+
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "include/proto"]
+	path = include/proto
+	url = https://github.com/MaracatronicsRobotics/Armorial-Proto.git

--- a/Armorial-PSEL.pro
+++ b/Armorial-PSEL.pro
@@ -1,0 +1,58 @@
+TEMPLATE = app
+DESTDIR  = ../bin
+TARGET   = Armorial-PSEL
+VERSION  = 1.0.0
+
+# Temporary dirs
+OBJECTS_DIR = tmp/obj
+MOC_DIR = tmp/moc
+UI_DIR = tmp/moc
+RCC_DIR = tmp/rc
+
+CONFIG += c++17 console
+CONFIG -= app_bundle
+QT += core network
+
+DEFINES += QT_DEPRECATED_WARNINGS
+LIBS += -lQt5Core -lprotobuf
+
+system(echo "Generating simulation proto headers" && cd include/proto/simulation && protoc --cpp_out=../ *.proto && cd ../../..)
+
+# The following define makes your compiler emit warnings if you use
+# any Qt feature that has been marked deprecated (the exact warnings
+# depend on your compiler). Please consult the documentation of the
+# deprecated API in order to know how to port your code away from it.
+DEFINES += QT_DEPRECATED_WARNINGS
+DEFINES += APP_NAME=\\\"$$TARGET\\\"
+DEFINES += APP_VERSION=\\\"$$VERSION\\\"
+DEFINES += PROJECT_PATH=\\\"$${PWD}\\\"
+
+# You can make your code fail to compile if it uses deprecated APIs.
+# In order to do so, uncomment the following line.
+#DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
+
+SOURCES += \
+        include/proto/command.pb.cc \
+        include/proto/common.pb.cc \
+        include/proto/packet.pb.cc \
+        include/proto/replacement.pb.cc \
+        main.cpp \
+        src/entities/actuator/actuator.cpp \
+        src/entities/coach/coach.cpp \
+        src/entities/player/player.cpp \
+        src/entities/vision/vision.cpp
+
+# Default rules for deployment.
+qnx: target.path = /tmp/$${TARGET}/bin
+else: unix:!android: target.path = /opt/$${TARGET}/bin
+!isEmpty(target.path): INSTALLS += target
+
+HEADERS += \
+    include/proto/command.pb.h \
+    include/proto/common.pb.h \
+    include/proto/packet.pb.h \
+    include/proto/replacement.pb.h \
+    src/entities/actuator/actuator.h \
+    src/entities/coach/coach.h \
+    src/entities/player/player.h \
+    src/entities/vision/vision.h

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,29 @@
+/***
+ * Maracatronics Robotics
+ * Federal University of Pernambuco (UFPE) at Recife
+ * http://www.maracatronics.com/
+ *
+ * This file is part of Armorial project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ***/
+
+#include <QCoreApplication>
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication a(argc, argv);
+
+    return a.exec();
+}

--- a/src/entities/actuator/actuator.cpp
+++ b/src/entities/actuator/actuator.cpp
@@ -1,0 +1,27 @@
+/***
+ * Maracatronics Robotics
+ * Federal University of Pernambuco (UFPE) at Recife
+ * http://www.maracatronics.com/
+ *
+ * This file is part of Armorial project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ***/
+
+#include "actuator.h"
+
+Actuator::Actuator()
+{
+
+}

--- a/src/entities/actuator/actuator.h
+++ b/src/entities/actuator/actuator.h
@@ -1,0 +1,32 @@
+/***
+ * Maracatronics Robotics
+ * Federal University of Pernambuco (UFPE) at Recife
+ * http://www.maracatronics.com/
+ *
+ * This file is part of Armorial project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ***/
+
+#ifndef ACTUATOR_H
+#define ACTUATOR_H
+
+
+class Actuator
+{
+public:
+    Actuator();
+};
+
+#endif // ACTUATOR_H

--- a/src/entities/coach/coach.cpp
+++ b/src/entities/coach/coach.cpp
@@ -1,0 +1,27 @@
+/***
+ * Maracatronics Robotics
+ * Federal University of Pernambuco (UFPE) at Recife
+ * http://www.maracatronics.com/
+ *
+ * This file is part of Armorial project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ***/
+
+#include "coach.h"
+
+Coach::Coach()
+{
+
+}

--- a/src/entities/coach/coach.h
+++ b/src/entities/coach/coach.h
@@ -1,0 +1,32 @@
+/***
+ * Maracatronics Robotics
+ * Federal University of Pernambuco (UFPE) at Recife
+ * http://www.maracatronics.com/
+ *
+ * This file is part of Armorial project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ***/
+
+#ifndef COACH_H
+#define COACH_H
+
+
+class Coach
+{
+public:
+    Coach();
+};
+
+#endif // COACH_H

--- a/src/entities/player/player.cpp
+++ b/src/entities/player/player.cpp
@@ -1,0 +1,27 @@
+/***
+ * Maracatronics Robotics
+ * Federal University of Pernambuco (UFPE) at Recife
+ * http://www.maracatronics.com/
+ *
+ * This file is part of Armorial project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ***/
+
+#include "player.h"
+
+Player::Player()
+{
+
+}

--- a/src/entities/player/player.h
+++ b/src/entities/player/player.h
@@ -1,0 +1,32 @@
+/***
+ * Maracatronics Robotics
+ * Federal University of Pernambuco (UFPE) at Recife
+ * http://www.maracatronics.com/
+ *
+ * This file is part of Armorial project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ***/
+
+#ifndef PLAYER_H
+#define PLAYER_H
+
+
+class Player
+{
+public:
+    Player();
+};
+
+#endif // PLAYER_H

--- a/src/entities/vision/vision.cpp
+++ b/src/entities/vision/vision.cpp
@@ -1,0 +1,27 @@
+/***
+ * Maracatronics Robotics
+ * Federal University of Pernambuco (UFPE) at Recife
+ * http://www.maracatronics.com/
+ *
+ * This file is part of Armorial project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ***/
+
+#include "vision.h"
+
+Vision::Vision()
+{
+
+}

--- a/src/entities/vision/vision.h
+++ b/src/entities/vision/vision.h
@@ -1,0 +1,32 @@
+/***
+ * Maracatronics Robotics
+ * Federal University of Pernambuco (UFPE) at Recife
+ * http://www.maracatronics.com/
+ *
+ * This file is part of Armorial project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ***/
+
+#ifndef VISION_H
+#define VISION_H
+
+
+class Vision
+{
+public:
+    Vision();
+};
+
+#endif // VISION_H


### PR DESCRIPTION
# What is the proposal of this pull request?
Base project which aims to enable working from develop

# What changes have been made?
I've created the base classes for the Armorial-PSEL project (Vision, Actuator, Coach and Player modules), inserted a build workflow for ubuntu (20.04 and 22.04 versions) and also inserted some templates for issue and pull request creations.

# How to test this changes?
Currently there is nothing that can be tested.

# References (screenshots, links, etc)
N/A

# Checklist
- [x] I have performed a self review on my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] My changes generated no new warnings

# Additional context
N/A