### PR TITLE
feat(vision): finished Vision module and integration with Player and WorldMap entities

### DIFF
--- a/Armorial-PSEL.pro
+++ b/Armorial-PSEL.pro
@@ -14,7 +14,7 @@ CONFIG -= app_bundle
 QT += core network
 
 DEFINES += QT_DEPRECATED_WARNINGS
-LIBS += -lQt5Core -lprotobuf
+LIBS += -lQt5Core -lprotobuf -lfmt
 
 system(echo "Generating simulation proto headers" && cd include/proto/simulation && protoc --cpp_out=../ *.proto && cd ../../..)
 
@@ -40,7 +40,8 @@ SOURCES += \
         src/entities/actuator/actuator.cpp \
         src/entities/coach/coach.cpp \
         src/entities/player/player.cpp \
-        src/entities/vision/vision.cpp
+        src/entities/vision/vision.cpp \
+        src/utils/types/robotdetectionpacket/robotdetectionpacket.cpp
 
 # Default rules for deployment.
 qnx: target.path = /tmp/$${TARGET}/bin
@@ -55,4 +56,5 @@ HEADERS += \
     src/entities/actuator/actuator.h \
     src/entities/coach/coach.h \
     src/entities/player/player.h \
-    src/entities/vision/vision.h
+    src/entities/vision/vision.h \
+    src/utils/types/robotdetectionpacket/robotdetectionpacket.h

--- a/Armorial-PSEL.pro
+++ b/Armorial-PSEL.pro
@@ -41,6 +41,7 @@ SOURCES += \
         src/entities/coach/coach.cpp \
         src/entities/player/player.cpp \
         src/entities/vision/vision.cpp \
+        src/entities/worldmap/worldmap.cpp \
         src/utils/types/robotdetectionpacket/robotdetectionpacket.cpp
 
 # Default rules for deployment.
@@ -57,4 +58,5 @@ HEADERS += \
     src/entities/coach/coach.h \
     src/entities/player/player.h \
     src/entities/vision/vision.h \
+    src/entities/worldmap/worldmap.h \
     src/utils/types/robotdetectionpacket/robotdetectionpacket.h

--- a/src/entities/player/player.h
+++ b/src/entities/player/player.h
@@ -1,4 +1,4 @@
-/***
+﻿/***
  * Maracatronics Robotics
  * Federal University of Pernambuco (UFPE) at Recife
  * http://www.maracatronics.com/
@@ -22,11 +22,85 @@
 #ifndef PLAYER_H
 #define PLAYER_H
 
+#include <QObject>
+#include <QVector2D>
 
-class Player
+#include <include/proto/packet.pb.h>
+#include <src/utils/types/robotdetectionpacket/robotdetectionpacket.h>
+
+// Constants for Player detection
+constexpr QVector2D OUT_OF_FIELD = QVector2D(std::numeric_limits<float>::max(),
+                                             std::numeric_limits<float>::max());
+constexpr int PACKETS_TILL_MISSING = 60;
+
+/*!
+ * \brief The Player class provides a implementation to manage a robot in the field, providing
+ * from simple getter methods (for position, id, orientation) to the robot control.
+ */
+class Player : public QObject
 {
+    Q_OBJECT
 public:
-    Player();
+    /*!
+     * \brief Player class constructor.
+     * \param isTeamBlue If this player belongs to the team blue.
+     * \param playerId This Player instance id.
+     */
+    Player(const bool& isTeamBlue, const quint8& playerId);
+
+    /*!
+     * \return True if the player is missing from detection and False otherwise.
+     */
+    bool isMissing() const;
+
+    /*!
+     * \return This Player instance object position at the field.
+     */
+    QVector2D getPosition() const;
+
+    /*!
+     * \return This Player instance object orientation at the field.
+     * \note For reference:
+     *             pi/2   pi/4
+     *               |   /
+     *               |  /
+     *               | /
+     *               |/
+     * +- pi ------------------ 0
+     *               |\
+     *               | \
+     *               |  \
+     *               |   \
+     *            -pi/2  -pi/4
+     */
+    float getOrientation() const;
+
+    /*!
+     * \return True if this Player instance belongs to team blue and False otherwise.
+     */
+    bool isTeamBlue() const;
+
+    /*!
+     * \return This Player instance id.
+     */
+    quint8 getPlayerId() const;
+
+private:
+    // Player internal variables
+    QVector2D _position;
+    float _orientation;
+    bool _isTeamBlue;
+    quint8 _playerId;
+
+    // Internal detection management
+    int _missingPackets;
+
+public slots:
+    /*!
+     * \brief Update this Player instance with a given detection packet.
+     * \param robotDetectionPacket The given detection packet.
+     */
+    void updateFromDetection(const RobotDetectionPacket& robotDetectionPacket);
 };
 
 #endif // PLAYER_H

--- a/src/entities/vision/vision.cpp
+++ b/src/entities/vision/vision.cpp
@@ -1,4 +1,4 @@
-/***
+﻿/***
  * Maracatronics Robotics
  * Federal University of Pernambuco (UFPE) at Recife
  * http://www.maracatronics.com/
@@ -21,7 +21,145 @@
 
 #include "vision.h"
 
-Vision::Vision()
-{
+#include <spdlog/spdlog.h>
 
+Vision::Vision(const QString& visionAddress, const quint16& visionPort)
+    : _visionAddress(visionAddress), _visionPort(visionPort)
+{
+    // Allocate vision socket pointer
+    _visionSocket = new QUdpSocket();
+
+    // Bind socket
+    _visionSocket->bind(QHostAddress::AnyIPv4, getVisionPort(), QUdpSocket::ShareAddress);
+
+    // Connects interface discover timer
+    _interfaceDiscoverTimer = new QTimer();
+    QObject::connect(_interfaceDiscoverTimer, &QTimer::timeout, this, &Vision::connectToNetwork);
+    _interfaceDiscoverTimer->start(1000);
+}
+
+Vision::~Vision() {
+    // Disconnect the vision socket from host
+    _visionSocket->disconnectFromHost();
+
+    // Delete timer and socket
+    delete _interfaceDiscoverTimer;
+    delete _visionSocket;
+}
+
+QString Vision::getVisionAddress() const {
+    return _visionAddress;
+}
+
+quint16 Vision::getVisionPort() const {
+    return _visionPort;
+}
+
+void Vision::receivePackets() {
+    // If reached here, the QUdpSocket has received a packet from the network. So, we mark the
+    // received any packets variable as true and disconnect the interface discover timer signal.
+    if(!_receivedAnyPackets) {
+        _receivedAnyPackets = true;
+        _interfaceDiscoverTimer->disconnect(SIGNAL(timeout()));
+        spdlog::info("Received vision packet!");
+    }
+
+    // Process the pending packets
+    while(_visionSocket->hasPendingDatagrams()) {
+        // Take datagram
+        QNetworkDatagram datagram = _visionSocket->receiveDatagram();
+
+        // Check if datagram is valid
+        if(!datagram.isValid()) continue;
+
+        // Try to parse to detection packet
+        fira_message::sim_to_ref::Environment wrapperData;
+        if(!wrapperData.ParseFromArray(datagram.data().data(), datagram.data().size())) {
+            spdlog::warn("Failed to convert vision datagram");
+            continue;
+        }
+
+        // Parse frame data from wrapper
+        if(wrapperData.has_frame()) {
+            // Get frame object
+            fira_message::Frame frame = wrapperData.frame();
+
+            // Send detected ball signal
+            emit sendBallDetection(frame.ball());
+
+            // Send detected blue robots
+            for(int i = 0; i < frame.robots_blue_size(); i++) {
+                // Get robot object
+                fira_message::Robot blueRobot = frame.robots_blue(i);
+
+                // Send detected blue robot signal
+                emit sendRobotDetection(RobotDetectionPacket(true, blueRobot));
+            }
+
+            // Send detected yellow robots
+            for(int i = 0; i < frame.robots_yellow_size(); i++) {
+                // Get robot object
+                fira_message::Robot yellowRobot = frame.robots_yellow(i);
+
+                // Send detected yellow robot signal
+                emit sendRobotDetection(RobotDetectionPacket(false, yellowRobot));
+            }
+        }
+
+        // Parse field data from wrapper
+        if(wrapperData.has_field()) {
+            // Get field object
+            fira_message::Field field = wrapperData.field();
+
+            // Send detected field signal
+            emit sendFieldDetection(field);
+        }
+    }
+}
+
+void Vision::connectToNetwork() {
+    // If has already connected to a valid interface, ignore
+    if(_receivedAnyPackets) return ;
+
+    // Try to found and connect the vision interface
+    QList<QNetworkInterface> availableInterfaces = QNetworkInterface::allInterfaces();
+
+    // Debug when not received any packet from the last try
+    if(_interfaceIndex != 0) {
+        spdlog::warn("Could not receive any vision packets from Vision at address '{}' and interface '{}'.",
+                     getVisionAddress().toStdString(),
+                     availableInterfaces.at(_interfaceIndex - 1).humanReadableName().toStdString());
+    }
+
+    // If could not connected to any interface, ignore
+    if(_interfaceIndex >= availableInterfaces.size()) {
+        spdlog::critical("Could not receive vision packets in any network interface.");
+        exit(-1);
+    }
+
+    // Get the next interface to try connection
+    const QNetworkInterface interface = availableInterfaces.at(_interfaceIndex);
+    QHostAddress visionHostAddress(getVisionAddress());
+    spdlog::info("Trying to connect to Vision at address '{}' and interface '{}'.",
+                 getVisionAddress().toStdString(), interface.humanReadableName().toStdString());
+
+    // Disconnect the readyRead signal from the vision socket and clear pending datagrams
+    _visionSocket->disconnect(SIGNAL(readyRead()));
+    while(_visionSocket->hasPendingDatagrams()) _visionSocket->receiveDatagram();
+
+    // Try to join the multicast group with the given address and interface
+    if(_visionSocket->joinMulticastGroup(visionHostAddress, interface)) {
+        _receivedAnyPackets = false;
+        spdlog::info("Connected to Vision at address '{}', port '{}' and interface '{}'.",
+                     getVisionAddress().toStdString(), getVisionPort(),
+                     interface.humanReadableName().toStdString());
+        QObject::connect(_visionSocket, &QUdpSocket::readyRead, this, &Vision::receivePackets);
+    }
+    else {
+        spdlog::error("Failed to join vision multicast group at address '{}' and interface '{}'.",
+                      getVisionAddress().toStdString(),
+                      interface.humanReadableName().toStdString());
+    }
+
+    _interfaceIndex++;
 }

--- a/src/entities/vision/vision.h
+++ b/src/entities/vision/vision.h
@@ -22,11 +22,93 @@
 #ifndef VISION_H
 #define VISION_H
 
+#include <QTimer>
+#include <QObject>
+#include <QUdpSocket>
+#include <QNetworkDatagram>
+#include <QNetworkInterface>
 
-class Vision
+#include <include/proto/packet.pb.h>
+#include <src/utils/types/robotdetectionpacket/robotdetectionpacket.h>
+
+/*!
+ * \brief The Vision class provides a implementation to receive vision data from the simulator,
+ * allowing to obtain information both of field objects (such as the ball or robots) and also
+ * from the field geometry (length, width, etc.).
+ */
+class Vision : public QObject
 {
+    Q_OBJECT
 public:
-    Vision();
+    /*!
+     * \brief Vision class constructor. It receives the network address to access the vision server
+     * and make the connections to enable data reception.
+     * \param visionAddress The vision network address.
+     * \param visionPort The vision network port.
+     */
+    Vision(const QString& visionAddress = "224.0.0.1", const quint16& visionPort = 10002);
+
+    /*!
+     * \brief Vision class destructor. It disconnects from the vision network and destroys the
+     * created socket and deallocate objects if any.
+     */
+    ~Vision();
+
+protected:
+    /*!
+     * \return The vision address that was given in the constructor.
+     */
+    QString getVisionAddress() const;
+
+    /*!
+     * \return The vision port that was given in the constructor.
+     */
+    quint16 getVisionPort() const;
+
+private:
+    // Internal network address variables
+    QString _visionAddress;
+    quint16 _visionPort;
+
+    // Socket and timer for data acquisition
+    QUdpSocket *_visionSocket;
+
+    // Interface discovery
+    QTimer *_interfaceDiscoverTimer;
+    bool _receivedAnyPackets = false;
+    int _interfaceIndex = 0;
+
+signals:
+    /*!
+     * \brief Send a robot detection packet signal to connected QObjects.
+     * \param robotDetectionPacket The robot detection packet which will be sent.
+     */
+    void sendRobotDetection(const RobotDetectionPacket& robotDetectionPacket);
+
+    /*!
+     * \brief Send a ball detection packet signal to connected QObjects.
+     * \param ballDetectionPacket The ball detection packet which will be sent.
+     */
+    void sendBallDetection(const fira_message::Ball& ballDetectionPacket);
+
+    /*!
+     * \brief Send a field detection packet signal to connected QObjects.
+     * \param fieldDetectionPacket The field detection packet which will be sent.
+     */
+    void sendFieldDetection(const fira_message::Field& fieldDetectionPacket);
+
+private slots:
+    /*!
+     * \brief Receive packets from the socket connected to the Vision server.
+     * \note This slot is called when the socket is in the ReadyRead state.
+     */
+    void receivePackets();
+
+    /*!
+     * \brief Makes the connection to network using the given network address and port.
+     * \return A boolean that indicates if the connection was succesfully or not.
+     */
+    void connectToNetwork();
 };
 
 #endif // VISION_H

--- a/src/entities/worldmap/worldmap.cpp
+++ b/src/entities/worldmap/worldmap.cpp
@@ -1,0 +1,143 @@
+﻿/***
+ * Maracatronics Robotics
+ * Federal University of Pernambuco (UFPE) at Recife
+ * http://www.maracatronics.com/
+ *
+ * This file is part of Armorial project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ***/
+
+
+#include "worldmap.h"
+
+WorldMap::WorldMap(const bool& isPlayingLeft) : _isPlayingLeft(isPlayingLeft)
+{
+
+}
+
+bool WorldMap::playingLeftSide() const {
+    return _isPlayingLeft;
+}
+
+float WorldMap::minX() const {
+    return -length()/2.0f;
+}
+
+float WorldMap::maxX() const {
+    return length()/2.0f;
+}
+
+float WorldMap::minY() const {
+    return -width()/2.0f;
+}
+
+float WorldMap::maxY() const {
+    return width()/2.0f;
+}
+
+float WorldMap::length() const {
+    return _field.length();
+}
+
+float WorldMap::width() const {
+    return _field.width();
+}
+
+float WorldMap::goalDepth() const {
+    return _field.goal_depth();
+}
+
+float WorldMap::goalWidth() const {
+    return _field.goal_width();
+}
+
+float WorldMap::penaltyDepth() const {
+    return 0.15f;
+}
+
+float WorldMap::penaltyWidth() const {
+    return 0.7f;
+}
+
+float WorldMap::penaltyMarkDistanceFromGoal() const {
+    return 0.1125f;
+}
+
+float WorldMap::centerRadius() const {
+    return 0.25f;
+}
+
+QVector2D WorldMap::ourGoalCenter() const {
+    if(playingLeftSide()) {
+        return QVector2D(-length()/2.0f, 0.0f);
+    }
+    else {
+        return QVector2D(length()/2.0f, 0.0f);
+    }
+}
+
+QVector2D WorldMap::ourGoalLeftPost() const {
+    QVector2D goalCenter = ourGoalCenter();
+    float offset = (playingLeftSide() ? -goalWidth()/2.0f : goalWidth()/2.0f);
+    return QVector2D(goalCenter.x(), goalCenter.y() + offset);
+}
+
+QVector2D WorldMap::ourGoalRightPost() const {
+    QVector2D goalCenter = ourGoalCenter();
+    float offset = (playingLeftSide() ? goalWidth()/2.0f : -goalWidth()/2.0f);
+    return QVector2D(goalCenter.x(), goalCenter.y() + offset);
+}
+
+QVector2D WorldMap::ourPenaltyMark() const {
+    QVector2D goalCenter = theirGoalCenter();
+    float offset = (playingLeftSide() ? -penaltyMarkDistanceFromGoal() : penaltyMarkDistanceFromGoal());
+    return QVector2D(goalCenter.x() - offset, goalCenter.y());
+}
+
+QVector2D WorldMap::theirGoalCenter() const {
+    // Take our goal center and just reflect the x coordinate
+    QVector2D ourCenter = ourGoalCenter();
+    return QVector2D(-ourCenter.x(), ourCenter.y());
+}
+
+QVector2D WorldMap::theirGoalLeftPost() const {
+    QVector2D goalCenter = theirGoalCenter();
+    float offset = (playingLeftSide() ? goalWidth()/2.0f : -goalWidth()/2.0f);
+    return QVector2D(goalCenter.x(), goalCenter.y() + offset);
+}
+
+QVector2D WorldMap::theirGoalRightPost() const {
+    QVector2D goalCenter = theirGoalCenter();
+    float offset = (playingLeftSide() ? -goalWidth()/2.0f : goalWidth()/2.0f);
+    return QVector2D(goalCenter.x(), goalCenter.y() + offset);
+}
+
+QVector2D WorldMap::theirPenaltyMark() const {
+    QVector2D goalCenter = ourGoalCenter();
+    float offset = (playingLeftSide() ? penaltyMarkDistanceFromGoal() : -penaltyMarkDistanceFromGoal());
+    return QVector2D(goalCenter.x() - offset, goalCenter.y());
+}
+
+QVector2D WorldMap::ballPosition() const {
+    return QVector2D(_ball.x(), _ball.y());
+}
+
+void WorldMap::updateBallDetection(const fira_message::Ball& ball) {
+    _ball = ball;
+}
+
+void WorldMap::updateFieldDetection(const fira_message::Field& field) {
+    _field = field;
+}

--- a/src/entities/worldmap/worldmap.h
+++ b/src/entities/worldmap/worldmap.h
@@ -1,0 +1,168 @@
+/***
+ * Maracatronics Robotics
+ * Federal University of Pernambuco (UFPE) at Recife
+ * http://www.maracatronics.com/
+ *
+ * This file is part of Armorial project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ***/
+
+
+#ifndef WORLDMAP_H
+#define WORLDMAP_H
+
+#include <QObject>
+#include <QMap>
+
+#include <include/proto/packet.pb.h>
+
+#include <src/entities/player/player.h>
+
+/*!
+ * \brief The WorldMap class provides an interface to access field data and objects, such as ball
+ * and some pre-defined field locations.
+ */
+class WorldMap : public QObject
+{
+    Q_OBJECT
+public:
+    /*!
+     * \brief WorldMap
+     * \param isPlayingLeft
+     */
+    WorldMap(const bool& isPlayingLeft);
+
+    /*!
+     * \return True if we are playing at left side and False otherwise.
+     */
+    bool playingLeftSide() const;
+
+    /*!
+     * \return The minimum x-axis value of the field.
+     */
+    float minX() const;
+
+    /*!
+     * \return The maximum x-axis value of the field.
+     */
+    float maxX() const;
+
+    /*!
+     * \return The minimum y-axis value of the field.
+     */
+    float minY() const;
+
+    /*!
+     * \return The maximum y-axis value of the field.
+     */
+    float maxY() const;
+
+    /*!
+     * \return The length of the field.
+     */
+    float length() const;
+
+    /*!
+     * \return The width of the field.
+     */
+    float width() const;
+
+    /*!
+     * \return The goal depth.
+     */
+    float goalDepth() const;
+
+    /*!
+     * \return The goal width.
+     */
+    float goalWidth() const;
+
+    /*!
+     * \return The penalty depth.
+     */
+    float penaltyDepth() const;
+
+    /*!
+     * \return The penalty width.
+     */
+    float penaltyWidth() const;
+
+    /*!
+     * \return The penalty mark distance from goal center.
+     */
+    float penaltyMarkDistanceFromGoal() const;
+
+    /*!
+     * \return The center radius.
+     */
+    float centerRadius() const;
+
+    /*!
+     * \return The position of the center of our goal.
+     */
+    QVector2D ourGoalCenter() const;
+
+    /*!
+     * \return The position of the right post of our goal.
+     */
+    QVector2D ourGoalRightPost() const;
+
+    /*!
+     * \return The position of the left post of our goal.
+     */
+    QVector2D ourGoalLeftPost() const;
+
+    /*!
+     * \return The position of our penalty mark.
+     */
+    QVector2D ourPenaltyMark() const;
+
+    /*!
+     * \return The position of the center of their goal.
+     */
+    QVector2D theirGoalCenter() const;
+
+    /*!
+     * \return The position of the right post of their goal.
+     */
+    QVector2D theirGoalRightPost() const;
+
+    /*!
+     * \return The position of the left post of their goal.
+     */
+    QVector2D theirGoalLeftPost() const;
+
+    /*!
+     * \return The position of their penalty mark.
+     */
+    QVector2D theirPenaltyMark() const;
+
+    /*!
+     * \return The position of the ball.
+     */
+    QVector2D ballPosition() const;
+
+private:
+    // Internal variables
+    fira_message::Field _field;
+    fira_message::Ball _ball;
+    bool _isPlayingLeft;
+
+public slots:
+    void updateBallDetection(const fira_message::Ball& ball);
+    void updateFieldDetection(const fira_message::Field& field);
+};
+
+#endif // WORLDMAP_H

--- a/src/utils/types/robotdetectionpacket/robotdetectionpacket.cpp
+++ b/src/utils/types/robotdetectionpacket/robotdetectionpacket.cpp
@@ -1,0 +1,38 @@
+/***
+ * Maracatronics Robotics
+ * Federal University of Pernambuco (UFPE) at Recife
+ * http://www.maracatronics.com/
+ *
+ * This file is part of Armorial project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ***/
+
+
+#include "robotdetectionpacket.h"
+
+RobotDetectionPacket::RobotDetectionPacket(const bool& isTeamBlue,
+                                           const fira_message::Robot& robotDetectionPacket)
+    : _isTeamBlue(isTeamBlue), _robotDetectionPacket(robotDetectionPacket)
+{
+
+}
+
+bool RobotDetectionPacket::isTeamBlue() const {
+    return _isTeamBlue;
+}
+
+fira_message::Robot RobotDetectionPacket::getRobotDetectionPacket() const {
+    return _robotDetectionPacket;
+}

--- a/src/utils/types/robotdetectionpacket/robotdetectionpacket.h
+++ b/src/utils/types/robotdetectionpacket/robotdetectionpacket.h
@@ -1,0 +1,58 @@
+/***
+ * Maracatronics Robotics
+ * Federal University of Pernambuco (UFPE) at Recife
+ * http://www.maracatronics.com/
+ *
+ * This file is part of Armorial project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ***/
+
+
+#ifndef ROBOTDETECTIONPACKET_H
+#define ROBOTDETECTIONPACKET_H
+
+#include <include/proto/packet.pb.h>
+
+/*!
+ * \brief The RobotDetectionPacket class provides an interface to enhance fira_message::Robot packet
+ * adding the team color data.
+ */
+class RobotDetectionPacket
+{
+public:
+    /*!
+     * \brief RobotDetectionPacket class constructor.
+     * \param isTeamBlue True if the detection packet is from team blue and False otherwise.
+     * \param robotDetectionPacket The robot detection packet itself (from Vision server).
+     */
+    RobotDetectionPacket(const bool& isTeamBlue, const fira_message::Robot& robotDetectionPacket);
+
+    /*!
+     * \return True if the robot detection packet is from team blue and False otherwise.
+     */
+    bool isTeamBlue() const;
+
+    /*!
+     * \return The robot detection packet associated with this class.
+     */
+    fira_message::Robot getRobotDetectionPacket() const;
+
+private:
+    // Internal vars
+    bool _isTeamBlue;
+    fira_message::Robot _robotDetectionPacket;
+};
+
+#endif // ROBOTDETECTIONPACKET_H


### PR DESCRIPTION
# What is the proposal of this pull request?
Vision module and integration with the Player and WorldMap entities.

# What changes have been made?
- Developed Vision module
- Created integration with the Player entity class
- Created integration with the WorldMap entity class

# How to test this changes?
You can create the Vision module pointer: open a FIRASim simulator instance and wait until it connects to the vision server.
After that, you can create and connect Player and WorldMap instances detection update slots to the Vision update signals: it is expected that these Players data (position, orientation) will be updated, the same for WorldMap.

# References (screenshots, links, etc)
N/A

# Checklist
- [x] I have performed a self review on my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] My changes generated no new warnings

# Additional context
N/A