### PR TITLE
chore(github): updating checkout action to v3, adding apt clean and removing apt upgrade

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,11 @@ jobs:
       matrix:
         os: [ ubuntu-20.04, ubuntu-22.04 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: "Install dependencies"
-        run: sudo apt-get update && sudo apt-get install build-essential cmake qtbase5-dev qt5-qmake libprotobuf-dev protobuf-compiler libprotoc-dev protobuf-compiler-grpc libgrpc++-dev libgrpc-dev libqt5serialport5-dev google-mock libgmock-dev libgtest-dev libspdlog-dev libfmt-dev && sudo apt-get upgrade
+        run: sudo apt-get clean && sudo apt-get update && sudo apt-get install build-essential cmake qtbase5-dev qt5-qmake libprotobuf-dev protobuf-compiler libprotoc-dev protobuf-compiler-grpc libgrpc++-dev libgrpc-dev libqt5serialport5-dev google-mock libgmock-dev libgtest-dev libspdlog-dev libfmt-dev
       - name: "Install Google Test library"
         run: cd /usr/src/googletest/googletest/ && sudo cmake CMakeLists.txt && sudo make && cd lib && sudo cp *.a /usr/lib
       - name: "Install Google Mock library"


### PR DESCRIPTION
# What is the proposal of this pull request?
Update github build workflow.

# What changes have been made?
- Changed the checkout actions to v3 (v2 was deprecated)
- Adding apt-get clean command to clean dependency tree
- Removing apt-get upgrade command beucase it is not necessary anymore.

# How to test this changes?
- Make a commit and waits until the pipeline is called to run.

# References (screenshots, links, etc)
https://discourse.julialang.org/t/node-js-12-actions-deprecation-warning-on-github/88718

# Checklist
- [x] I have performed a self review on my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] My changes generated no new warnings

# Additional context
N/A